### PR TITLE
Point coordinates may contain more than two elements (closes #112)

### DIFF
--- a/src/component/point-geom/geom.vue
+++ b/src/component/point-geom/geom.vue
@@ -8,7 +8,7 @@
     coordinates: {
       type: Array,
       required: true,
-      validator: value => value.length === 2,
+      validator: value => value.length >= 2,
     },
   }
 


### PR DESCRIPTION
According to [The GeoJSON Format description (Paragraph 3.1.1. Position)](https://tools.ietf.org/html/rfc7946#section-3.1.1), each position of geometry may include more than two elements