### PR TITLE
closing tag didn't match opening tag in docs

### DIFF
--- a/docs/component/tile-layer.md
+++ b/docs/component/tile-layer.md
@@ -30,7 +30,7 @@ and with [`vl-source-sputnik`](/docs/component/sputnik-source.md).
     
     <vl-layer-tile id="wmts">
       <vl-source-wmts :attributions="attribution" :url="url" :layer-name="layerName" :matrix-set="matrixSet" :format="format" 
-                      :style-name="styleName"></vl-source-image-static>
+                      :style-name="styleName"></vl-source-wmts>
     </vl-layer-tile>
   </vl-map>
 </template>


### PR DESCRIPTION
In this URL:

https://vuelayers.github.io/#/docs/component/tile-layer?id=usage

the code had a source-image-static closing a source-wmts