### PR TITLE
Add missing scaling of draw interaction circles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1909,7 +1909,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -10991,7 +10990,6 @@
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -11010,7 +11008,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11104,7 +11101,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11190,8 +11186,7 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11297,8 +11292,7 @@
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -12074,8 +12068,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -20028,7 +20021,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }

--- a/src/ol-ext/format.js
+++ b/src/ol-ext/format.js
@@ -6,6 +6,8 @@ import { EPSG_4326 } from './consts'
 import { createCircularPolygon } from './geom'
 import { transformPoint } from './proj'
 import { isCircle } from './util'
+import LineString from 'ol/geom/LineString'
+import { getLength } from 'ol/sphere'
 
 /**
  * @param {Object} [options]
@@ -34,13 +36,16 @@ export function createMvtFmt (options) {
 class GeoJSON extends BaseGeoJSON {
   writeGeometryObject (geometry, options) {
     if (isCircle(geometry)) {
+      const start = geometry.getCenter()
+      const end = [start[0] + geometry.getRadius(), start[1]]
+      const radius = getLength(new LineString([start, end]), options.featureProjection || this.defaultFeatureProjection)
       geometry = createCircularPolygon(
         transformPoint(
           geometry.getCenter(),
           options.featureProjection || this.defaultFeatureProjection,
           EPSG_4326,
         ),
-        geometry.getRadius(),
+        radius
       )
       options.featureProjection = EPSG_4326
     }


### PR DESCRIPTION
If draw interaction circles are synced to a geojson feature array, their
radius should be scaled to reflect the difference in scale factor
between the map view projection and ESPG:4236 used for geojson.

Currently, using an OSM base map and an EPSG:3857 view, synced GeoJSON "circles" (actually polygons) are larger than the drawn feature by an amount depending on latitude because no adjustment is made for the variable local scale factor.  Below is an example from the south of the UK.

![Screenshot_20190502_104424](https://user-images.githubusercontent.com/4785476/57067604-64fb6700-6cc7-11e9-89ad-3b6775ac9442.png)