### PR TITLE
add to each component the module it comes from

### DIFF
--- a/docs/component/bingmaps-source.md
+++ b/docs/component/bingmaps-source.md
@@ -5,11 +5,11 @@
 `vl-source-bingmaps` adds ability to display tile data from Bing Maps. To use
 this source you should get **API key** at https://www.bingmapsportal.com.
 
-## Versions
+## ES6 Module
 
-`vl-source-bingmaps` is a part of **BingmapsSource** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/bingmaps-source/
+```javascript
+import { BingmapsSource } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/bingmaps-source.md
+++ b/docs/component/bingmaps-source.md
@@ -9,6 +9,8 @@ this source you should get **API key** at https://www.bingmapsportal.com.
 
 ```javascript
 import { BingmapsSource } from 'vuelayers'
+
+Vue.use(BingmapsSource)
 ```
 
 ## Usage

--- a/docs/component/circle-geom.md
+++ b/docs/component/circle-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { CircleGeom } from 'vuelayers'
+
+Vue.use(CircleGeom);
 ```

--- a/docs/component/circle-geom.md
+++ b/docs/component/circle-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-circle
+
+## ES6 Module
+
+```javascript
+import { CircleGeom } from 'vuelayers'
+```

--- a/docs/component/circle-style.md
+++ b/docs/component/circle-style.md
@@ -1,1 +1,7 @@
 # vl-style-circle
+
+## ES6 Module
+
+```javascript
+import { CircleStyle } from 'vuelayers'
+```

--- a/docs/component/circle-style.md
+++ b/docs/component/circle-style.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { CircleStyle } from 'vuelayers'
+
+Vue.use(CircleStyle)
 ```

--- a/docs/component/draw-interaction.md
+++ b/docs/component/draw-interaction.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { DrawInteraction } from 'vuelayers'
+
+Vue.use(DrawInteraction)
 ```

--- a/docs/component/draw-interaction.md
+++ b/docs/component/draw-interaction.md
@@ -1,1 +1,7 @@
 # vl-interaction-draw
+
+## ES6 Module
+
+```javascript
+import { DrawInteraction } from 'vuelayers'
+```

--- a/docs/component/feature.md
+++ b/docs/component/feature.md
@@ -13,11 +13,11 @@ components, without geometry component nothing will be rendered.
 Custom feature styles can be applied with [`vl-style-*`](/docs/component/circle-style.md) 
 components placed inside default slot.
 
-## Versions
+## ES6 Module
 
-`vl-feature` component is a part of **Feature** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/feature/
+```javascript
+import { Feature } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/feature.md
+++ b/docs/component/feature.md
@@ -17,6 +17,8 @@ components placed inside default slot.
 
 ```javascript
 import { Feature } from 'vuelayers'
+
+Vue.use(Feature)
 ```
 
 ## Usage

--- a/docs/component/geoloc.md
+++ b/docs/component/geoloc.md
@@ -10,6 +10,8 @@ a user's position. You can place it to the **default slot** of [`vl-map`](/docs/
 
 ```javascript
 import { Geoloc } from 'vuelayers'
+
+Vue.use(Geoloc)
 ```
 
 ## Usage

--- a/docs/component/geoloc.md
+++ b/docs/component/geoloc.md
@@ -6,11 +6,11 @@
 The [Geolocation API](https://www.w3.org/TR/geolocation-API/) is used to locate 
 a user's position. You can place it to the **default slot** of [`vl-map`](/docs/component/map.md) component.
 
-## Versions
+## ES6 Module
 
-`vl-geoloc` is a part of **Geoloc** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/geoloc/
+```javascript
+import { Geoloc } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/image-layer.md
+++ b/docs/component/image-layer.md
@@ -9,6 +9,8 @@ raster source, like [`vl-source-image-static`](/docs/component/image-static-sour
 
 ```javascript
 import { ImageLayer } from 'vuelayers'
+
+Vue.use(ImageLayer)
 ```
 
 ## Usage

--- a/docs/component/image-layer.md
+++ b/docs/component/image-layer.md
@@ -5,11 +5,11 @@
 `vl-layer-image` components can render any server-rendered image, it is a container for
 raster source, like [`vl-source-image-static`](/docs/component/image-static-source.md).
 
-## Versions
+## ES6 Module
 
-`vl-layer-image` component is a part of **ImageLayer** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/image-layer/
+```javascript
+import { ImageLayer } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/image-static-source.md
+++ b/docs/component/image-static-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { ImageStaticSource } from 'vuelayers'
+
+Vue.use(ImageStaticSource)
 ```

--- a/docs/component/image-static-source.md
+++ b/docs/component/image-static-source.md
@@ -1,3 +1,7 @@
 # vl-image-static-source
 
-// TODO
+## ES6 Module
+
+```javascript
+import { ImageStaticSource } from 'vuelayers'
+```

--- a/docs/component/image-wms-source.md
+++ b/docs/component/image-wms-source.md
@@ -1,3 +1,7 @@
 # vl-image-wms-source
 
-// TODO
+## ES6 Module
+
+```javascript
+import { ImageWmsSource } from 'vuelayers'
+```

--- a/docs/component/image-wms-source.md
+++ b/docs/component/image-wms-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { ImageWmsSource } from 'vuelayers'
+
+Vue.use(ImageWmsSource)
 ```

--- a/docs/component/line-string-geom.md
+++ b/docs/component/line-string-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { LineStringGeom } from 'vuelayers'
+
+Vue.use(LineStringGeom)
 ```

--- a/docs/component/line-string-geom.md
+++ b/docs/component/line-string-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-line-string
+
+## ES6 Module
+
+```javascript
+import { LineStringGeom } from 'vuelayers'
+```

--- a/docs/component/map.md
+++ b/docs/component/map.md
@@ -10,6 +10,8 @@ component to setup `zoom`, `center`, `projection` and other view related propeti
 
 ```javascript
 import { Map } from 'vuelayers'
+
+Vue.use(Map)
 ```
 
 ## Usage

--- a/docs/component/map.md
+++ b/docs/component/map.md
@@ -6,11 +6,11 @@ It is a main container for all other VueLayers components and has one `default`
 slot to place them all. Usually you will use it together with [`vl-view`](/docs/component/view.md) 
 component to setup `zoom`, `center`, `projection` and other view related propeties for the map.
 
-## Module system
+## ES6 Module
 
-`vl-map` component is a part of **Map** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/map/
+```javascript
+import { Map } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/modify-interaction.md
+++ b/docs/component/modify-interaction.md
@@ -1,1 +1,7 @@
 # vl-interaction-modify
+
+## ES6 Module
+
+```javascript
+import { ModifyInteraction } from 'vuelayers'
+```

--- a/docs/component/modify-interaction.md
+++ b/docs/component/modify-interaction.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { ModifyInteraction } from 'vuelayers'
+
+Vue.use(ModifyInteraction)
 ```

--- a/docs/component/multi-line-string-geom.md
+++ b/docs/component/multi-line-string-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { MultiLineStringGeom } from 'vuelayers'
+
+Vue.use(MultiLineStringGeom)
 ```

--- a/docs/component/multi-line-string-geom.md
+++ b/docs/component/multi-line-string-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-multi-line-string
+
+## ES6 Module
+
+```javascript
+import { MultiLineStringGeom } from 'vuelayers'
+```

--- a/docs/component/multi-point-geom.md
+++ b/docs/component/multi-point-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { MultiPointGeom } from 'vuelayers'
+
+Vue.use(MultiPointGeom)
 ```

--- a/docs/component/multi-point-geom.md
+++ b/docs/component/multi-point-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-multi-point
+
+## ES6 Module
+
+```javascript
+import { MultiPointGeom } from 'vuelayers'
+```

--- a/docs/component/multi-polygon-geom.md
+++ b/docs/component/multi-polygon-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-multi-polygon
+
+## ES6 Module
+
+```javascript
+import { MultiPolygonGeom } from 'vuelayers'
+```

--- a/docs/component/multi-polygon-geom.md
+++ b/docs/component/multi-polygon-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { MultiPolygonGeom } from 'vuelayers'
+
+Vue.use(MultiPolygonGeom)
 ```

--- a/docs/component/osm-source.md
+++ b/docs/component/osm-source.md
@@ -1,1 +1,7 @@
 # vl-source-osm
+
+## ES6 Module
+
+```javascript
+import { OsmSource } from 'vuelayers'
+```

--- a/docs/component/osm-source.md
+++ b/docs/component/osm-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { OsmSource } from 'vuelayers'
+
+Vue.use(OsmSource)
 ```

--- a/docs/component/overlay.md
+++ b/docs/component/overlay.md
@@ -7,11 +7,11 @@ the map. It has **default** scoped slot to render your custom content. You can
 place it any component with slot inside the map components tree to easily bind
 it to some coordinate (for example: inside `vl-feature` or `vl-view`).
 
-## Versions
+## ES6 Module
 
-`vl-overlay` component is a part of **Overlay** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/overlay/
+```javascript
+import { Overlay } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/overlay.md
+++ b/docs/component/overlay.md
@@ -11,6 +11,8 @@ it to some coordinate (for example: inside `vl-feature` or `vl-view`).
 
 ```javascript
 import { Overlay } from 'vuelayers'
+
+Vue.use(Overlay)
 ```
 
 ## Usage

--- a/docs/component/point-geom.md
+++ b/docs/component/point-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-point
+
+## ES6 Module
+
+```javascript
+import { PointGeom } from 'vuelayers'
+```

--- a/docs/component/point-geom.md
+++ b/docs/component/point-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { PointGeom } from 'vuelayers'
+
+Vue.use(PointGeom)
 ```

--- a/docs/component/polygon-geom.md
+++ b/docs/component/polygon-geom.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { PolygonGeom } from 'vuelayers'
+
+Vue.use(PolygonGeom)
 ```

--- a/docs/component/polygon-geom.md
+++ b/docs/component/polygon-geom.md
@@ -1,1 +1,7 @@
 # vl-geom-polygon
+
+## ES6 Module
+
+```javascript
+import { PolygonGeom } from 'vuelayers'
+```

--- a/docs/component/select-interaction.md
+++ b/docs/component/select-interaction.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { SelectInteraction } from 'vuelayers'
+
+Vue.use(SelectInteraction)
 ```

--- a/docs/component/select-interaction.md
+++ b/docs/component/select-interaction.md
@@ -1,1 +1,7 @@
 # vl-interaction-select
+
+## ES6 Module
+
+```javascript
+import { SelectInteraction } from 'vuelayers'
+```

--- a/docs/component/snap-interaction.md
+++ b/docs/component/snap-interaction.md
@@ -1,1 +1,7 @@
 # vl-interaction-snap
+
+## ES6 Module
+
+```javascript
+import { SnapInteraction } from 'vuelayers'
+```

--- a/docs/component/snap-interaction.md
+++ b/docs/component/snap-interaction.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { SnapInteraction } from 'vuelayers'
+
+Vue.use(SnapInteraction)
 ```

--- a/docs/component/sputnik-source.md
+++ b/docs/component/sputnik-source.md
@@ -1,1 +1,7 @@
 # vl-source-sputnik
+
+## ES6 Module
+
+```javascript
+import { SputnikSource } from 'vuelayers'
+```

--- a/docs/component/sputnik-source.md
+++ b/docs/component/sputnik-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { SputnikSource } from 'vuelayers'
+
+Vue.use(SputnikSource)
 ```

--- a/docs/component/style-box.md
+++ b/docs/component/style-box.md
@@ -1,1 +1,7 @@
 # vl-style-box
+
+## ES6 Module
+
+```javascript
+import { StyleBox } from 'vuelayers'
+```

--- a/docs/component/style-box.md
+++ b/docs/component/style-box.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { StyleBox } from 'vuelayers'
+
+Vue.use(StyleBox)
 ```

--- a/docs/component/tile-layer.md
+++ b/docs/component/tile-layer.md
@@ -6,11 +6,11 @@
 grids organized by zoom levels. It should be used together with tiled source components like
 [`vl-source-xyz`](/docs/component/xyz-source.md), [`vl-source-wmts`](/docs/component/wmts-source.md), [`vl-source-osm`](/docs/component/osm-source.md).
 
-## Versions
+## ES6 Module
 
-`vl-layer-tile` component is a part of **TileLayer** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/tile-layer/
+```javascript
+import { TileLayer } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/tile-layer.md
+++ b/docs/component/tile-layer.md
@@ -10,6 +10,8 @@ grids organized by zoom levels. It should be used together with tiled source com
 
 ```javascript
 import { TileLayer } from 'vuelayers'
+
+Vue.use(TileLayer)
 ```
 
 ## Usage

--- a/docs/component/vector-layer.md
+++ b/docs/component/vector-layer.md
@@ -5,11 +5,11 @@
 `vl-layer-vector` can render vector from verious backend services. It should be
 used with together with [`vl-source-vector`](/docs/component/vector-source.md) component.
 
-## Versions
+## ES6 Module
 
-`vl-layer-vector` is a part of **VectorLayer** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/vector-layer/
+```javascript
+import { VectorLayer } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/vector-layer.md
+++ b/docs/component/vector-layer.md
@@ -9,6 +9,8 @@ used with together with [`vl-source-vector`](/docs/component/vector-source.md) c
 
 ```javascript
 import { VectorLayer } from 'vuelayers'
+
+Vue.use(VectorLayer)
 ```
 
 ## Usage

--- a/docs/component/vector-source.md
+++ b/docs/component/vector-source.md
@@ -9,6 +9,8 @@ draw any vector data on the map.
 
 ```javascript
 import { VectorSource } from 'vuelayers'
+
+Vue.use(VectorSource)
 ```
 
 ## Usage

--- a/docs/component/vector-source.md
+++ b/docs/component/vector-source.md
@@ -5,9 +5,11 @@
 `vl-source-vector` can be used together with [`vl-layer-vector`](/docs/component/vector-layer.md) to
 draw any vector data on the map.
 
-# Versions
+## ES6 Module
 
-- **ES6**: https://unpkg.com/vuelayers/lib/vector-source/
+```javascript
+import { VectorSource } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/vector-tile-layer.md
+++ b/docs/component/vector-tile-layer.md
@@ -5,11 +5,11 @@
 `vl-layer-vector-tile` can render tiled vector data in grids organized by zoom levels. It should be used together with 
 [`vl-source-vector-tile`](/docs/component/vector-tile-source.md) component.
 
-## Versions
+## ES6 Module
 
-`vl-layer-vector-tile` component is a part of **VectorTileLayer** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/vector-tile-layer/
+```javascript
+import { VectorTileLayer } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/vector-tile-layer.md
+++ b/docs/component/vector-tile-layer.md
@@ -9,6 +9,8 @@
 
 ```javascript
 import { VectorTileLayer } from 'vuelayers'
+
+Vue.use(VectorTileLayer)
 ```
 
 ## Usage

--- a/docs/component/vector-tile-source.md
+++ b/docs/component/vector-tile-source.md
@@ -1,1 +1,7 @@
 # vl-source-vector-tile
+
+## ES6 Module
+
+```javascript
+import { VectorTileSource } from 'vuelayers'
+```

--- a/docs/component/vector-tile-source.md
+++ b/docs/component/vector-tile-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { VectorTileSource } from 'vuelayers'
+
+Vue.use(VectorTileSource)
 ```

--- a/docs/component/view.md
+++ b/docs/component/view.md
@@ -5,11 +5,12 @@
 `vl-view` is the component to act upon to change the **center**, **resolution** 
 and **rotation** of the map.
 
-## Versions
+## ES6 Module
 
-`vl-view` component is a part of **Map** module:
-
-- **ES6**: https://unpkg.com/vuelayers/lib/map/
+```javascript
+// vl-view component comes with vl-map
+import { Map } from 'vuelayers'
+```
 
 ## Usage
 

--- a/docs/component/view.md
+++ b/docs/component/view.md
@@ -10,6 +10,8 @@ and **rotation** of the map.
 ```javascript
 // vl-view component comes with vl-map
 import { Map } from 'vuelayers'
+
+Vue.use(Map)
 ```
 
 ## Usage

--- a/docs/component/wms-source.md
+++ b/docs/component/wms-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { WmsSource } from 'vuelayers'
+
+Vue.use(WmsSource)
 ```

--- a/docs/component/wms-source.md
+++ b/docs/component/wms-source.md
@@ -1,1 +1,7 @@
 # vl-source-wms
+
+## ES6 Module
+
+```javascript
+import { WmsSource } from 'vuelayers'
+```

--- a/docs/component/wmts-source.md
+++ b/docs/component/wmts-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { WmtsSource } from 'vuelayers'
+
+Vue.use(WmtsSource)
 ```

--- a/docs/component/wmts-source.md
+++ b/docs/component/wmts-source.md
@@ -1,1 +1,7 @@
 # vl-source-wmts
+
+## ES6 Module
+
+```javascript
+import { WmtsSource } from 'vuelayers'
+```

--- a/docs/component/xyz-source.md
+++ b/docs/component/xyz-source.md
@@ -4,4 +4,6 @@
 
 ```javascript
 import { XyzSource } from 'vuelayers'
+
+Vue.use(XyzSource)
 ```

--- a/docs/component/xyz-source.md
+++ b/docs/component/xyz-source.md
@@ -1,1 +1,7 @@
 # vl-source-xyz
+
+## ES6 Module
+
+```javascript
+import { XyzSource } from 'vuelayers'
+```


### PR DESCRIPTION
The only thing I'm not so sure about is `vl-view` because it is not directly exported as module but I cannot explain from the source how am I able to use it without importing it explicitly.

Other than that this should close #178.

Doing this I realized it might be a good idea to include a line with `Vue.use(Component)` as part of every **ES6 Module** block but I don't know how helpful/confusing that would be.