### PR TITLE
add placeholders for the missing style docs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -51,6 +51,12 @@
 
     * [vl-style-box](/docs/component/style-box.md)
     * [vl-style-circle](/docs/component/circle-style.md)
+    * [vl-style-fill](/docs/component/fill-style.md)
+    * [vl-style-func](/docs/component/func-style.md)
+    * [vl-style-icon](/docs/component/icon-style.md)
+    * [vl-style-reg-shape](/docs/component/reg-shape-style.md)
+    * [vl-style-stroke](/docs/component/stroke-style.md)
+    * [vl-style-text](/docs/component/text-style.md)
 
 * Mixins
   

--- a/docs/component/fill-style.md
+++ b/docs/component/fill-style.md
@@ -1,0 +1,9 @@
+# vl-style-fill
+
+## ES6 Module
+
+```javascript
+import { FillStyle } from 'vuelayers'
+
+Vue.use(FillStyle)
+```

--- a/docs/component/func-style.md
+++ b/docs/component/func-style.md
@@ -1,0 +1,9 @@
+# vl-style-func
+
+## ES6 Module
+
+```javascript
+import { StyleFunc } from 'vuelayers'
+
+Vue.use(StyleFunc)
+```

--- a/docs/component/icon-style.md
+++ b/docs/component/icon-style.md
@@ -1,0 +1,9 @@
+# vl-style-icon
+
+## ES6 Module
+
+```javascript
+import { IconStyle } from 'vuelayers'
+
+Vue.use(IconStyle)
+```

--- a/docs/component/reg-shape-style.md
+++ b/docs/component/reg-shape-style.md
@@ -1,0 +1,9 @@
+# vl-style-reg-shape
+
+## ES6 Module
+
+```javascript
+import { RegShapeStyle } from 'vuelayers'
+
+Vue.use(RegShapeStyle)
+```

--- a/docs/component/stroke-style.md
+++ b/docs/component/stroke-style.md
@@ -1,0 +1,9 @@
+# vl-style-stroke
+
+## ES6 Module
+
+```javascript
+import { StrokeStyle } from 'vuelayers'
+
+Vue.use(StrokeStyle)
+```

--- a/docs/component/text-style.md
+++ b/docs/component/text-style.md
@@ -1,0 +1,9 @@
+# vl-style-text
+
+## ES6 Module
+
+```javascript
+import { TextStyle } from 'vuelayers'
+
+Vue.use(TextStyle)
+```


### PR DESCRIPTION
6 styles are documented here. In a follow up PR I'll add the content but this gives a good idea of what the options for styling vectors are.