### PR TITLE
improve map component defaultInteractionsOptions prop

### DIFF
--- a/src/component/map/map.vue
+++ b/src/component/map/map.vue
@@ -49,6 +49,15 @@
         default: true,
       },
       /**
+       * Options for default interactions added to the map by default. Object
+       * value is used to configure default interactions.
+       * @type {Object}
+       */
+      defaultInteractionsOptions: {
+        type: Object,
+        default: () => ({}),
+      },
+      /**
        * The element to listen to keyboard events on. For example, if this option is set to `document` the keyboard
        * interactions will always trigger. If this option is not specified, the element the library listens to keyboard
        * events on is the component root element.
@@ -342,7 +351,7 @@
         : new Collection()
       // initialize default set of interactions
       // todo initialize without interactions and provide vl-interaction-default component
-      const interactions = createDefaultInteractions()
+      const interactions = createDefaultInteractions(this.defaultInteractionsOptions)
       interactions.forEach(interaction => initializeInteraction(interaction))
       this._interactionsCollection = interactions
       // prepare default overlay


### PR DESCRIPTION
Added a defaultInteractionsOptions prop to the map component to be able to pass options into the interactions defaults function when map.vue calls it. 
I mainly needed a way to add the onFocusOnly boolean in so the DragPan and MouseWheelZoom interactions only activate on map focus. I tried many other ways to accomplish this without having to create a set of interactions of my own. I even tried setting the interactions on mounted and created using the defaults function the same way the map component does, but for some reason the map property didn't get set for the interactions and openlayers was logging errors to the console any time I used DragPan.