### PR TITLE
Changed plugin source to fix "missing plugins" error

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,7 +65,7 @@ Then in the `nuxt.config.js` file, fill in the plugins and modules section prope
 
 ```
 plugins: [{
-		src: '@/plugins/vueLayers',
+		src: '@/plugins/vuelayers.js',
 		ssr: false
 	}, { ... }],
 modules: [


### PR DESCRIPTION
Following quickstart on Nuxt latest I got an error "Missing plugin".
Fixed it by changing it to file+extension format in Nuxt config