### PR TITLE
Review data/view projections resolving

### DIFF
--- a/src/components/draw-interaction/interaction.vue
+++ b/src/components/draw-interaction/interaction.vue
@@ -20,7 +20,7 @@
     upperFirst,
   } from '../../utils'
 
-  const transformType = type => upperFirst(camelCase(type))
+  const transformType = /*#__PURE__*/type => upperFirst(camelCase(type))
 
   export default {
     name: 'VlInteractionDraw',

--- a/src/components/feature/circle-geom.vue
+++ b/src/components/feature/circle-geom.vue
@@ -91,8 +91,8 @@
       },
     },
     watch: {
-      async radiusDataProj (value) {
-        await this.setRadius(value)
+      async radiusViewProj (value) {
+        await this.setRadius(value, true)
       },
       currentRadiusDataProj: /*#__PURE__*/debounce(function (value) {
         if (value === this.radiusDataProj) return
@@ -221,10 +221,10 @@
         (await this.resolveGeometry()).setCenterAndRadius(center, radius)
       },
       radiusToViewProj (radius) {
-        return transformDistance(radius, this.resolvedRadiusProjection, this.viewProjection)
+        return transformDistance(radius, this.resolvedRadiusProjection, this.resolvedViewProjection)
       },
       radiusToDataProj (radius) {
-        return transformDistance(radius, this.viewProjection, this.resolvedRadiusProjection)
+        return transformDistance(radius, this.resolvedViewProjection, this.resolvedRadiusProjection)
       },
     },
   }

--- a/src/components/graticule-layer/layer.vue
+++ b/src/components/graticule-layer/layer.vue
@@ -48,7 +48,7 @@
 <script>
   import debounce from 'debounce-promise'
   import GraticuleLayer from 'ol/layer/Graticule'
-  import { vectorLayer } from '../../mixins'
+  import { FRAME_TIME, vectorLayer } from '../../mixins'
   import { dumpStrokeStyle, dumpTextStyle } from '../../ol-ext'
   import { clonePlainObject, isEqual, isFunction, makeWatchers, map, mergeDescriptors } from '../../utils'
   import { FillStyle, StrokeStyle, TextStyle } from '../style'
@@ -136,7 +136,7 @@
           if (isEqual(value, prev)) return
 
           this.$emit('update:meridians', clonePlainObject(value))
-        }),
+        }, FRAME_TIME),
       },
       currentParallels: {
         deep: true,
@@ -144,7 +144,7 @@
           if (isEqual(value, prev)) return
 
           this.$emit('update:parallels', clonePlainObject(value))
-        }),
+        }, FRAME_TIME),
       },
       currentLonLabelStyle: {
         deep: true,
@@ -152,7 +152,7 @@
           if (isEqual(value, prev)) return
 
           this.$emit('update:lonLabelStyle', clonePlainObject(value))
-        }),
+        }, FRAME_TIME),
       },
       currentLatLabelStyle: {
         deep: true,
@@ -160,7 +160,7 @@
           if (isEqual(value, prev)) return
 
           this.$emit('update:latLabelStyle', clonePlainObject(value))
-        }),
+        }, FRAME_TIME),
       },
       currentStrokeStyle: {
         deep: true,
@@ -168,7 +168,7 @@
           if (isEqual(value, prev)) return
 
           this.$emit('update:strokeStyle', clonePlainObject(value))
-        }),
+        }, FRAME_TIME),
       },
       .../*#__PURE__*/makeWatchers([
         'maxLines',

--- a/src/components/image-arcgis-rest-source/source.vue
+++ b/src/components/image-arcgis-rest-source/source.vue
@@ -46,7 +46,7 @@
         return new ImageArcGISRestSource({
           // ol/source/Source
           attributions: this.currentAttributions,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           // ol/source/Image
           resolutions: this.resolutions,
           // ol/source/ImageArcGISRest

--- a/src/components/image-static-source/source.vue
+++ b/src/components/image-static-source/source.vue
@@ -145,7 +145,7 @@
         return new ImageStaticSource({
           // ol/source/Source
           attributions: this.currentAttributions,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           // ol/source/ImageStatic
           crossOrigin: this.crossOrigin,
           imageExtent: this.resolvedImgExtent,

--- a/src/components/image-wms-source/source.vue
+++ b/src/components/image-wms-source/source.vue
@@ -46,7 +46,7 @@
         return new ImageWMSSource({
           // ol/source/Source
           attributions: this.currentAttributions,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           // ol/source/Image
           resolutions: this.resolutions,
           // ol/source/ImageWMS

--- a/src/components/mapbox-source/source.vue
+++ b/src/components/mapbox-source/source.vue
@@ -3,7 +3,7 @@
   import { coalesce } from '../../utils'
 
   const MAPBOX_URL_TEMPLATE = 'https://{a-c}.tiles.mapbox.com/v4/{mapId}/{z}/{x}/{y}{tileNameSuffix}.{tileFormat}?access_token={accessToken}'
-  const MAPBOX_ATTRIBUTIONS = '&copy; <a href="https://www.mapbox.com/" target="_blank">MapBox</a>, ' + (new Date().getFullYear())
+  const MAPBOX_ATTRIBUTIONS = '&copy; <a href="https://www.mapbox.com/" target="_blank">MapBox</a>.'
 
   export default {
     name: 'VlSourceMapbox',

--- a/src/components/modify-interaction/interaction.vue
+++ b/src/components/modify-interaction/interaction.vue
@@ -103,6 +103,7 @@
       async createInteraction () {
         let source = this._source = await this.getInstance(this.source)
         assert(!!source, `Source "${this.source}" not found in identity map.`)
+
         let features
         if (source instanceof VectorSource) {
           features = source.getFeaturesCollection()

--- a/src/components/select-interaction/interaction.vue
+++ b/src/components/select-interaction/interaction.vue
@@ -142,7 +142,7 @@
             coordinates: transforms[feature.geometry.type].transform(
               feature.geometry.coordinates,
               this.resolvedDataProjection,
-              this.viewProjection,
+              this.resolvedViewProjection,
             ),
           },
         }))
@@ -157,12 +157,12 @@
       },
     },
     watch: {
-      featuresDataProj: {
+      featuresViewProj: {
         deep: true,
         handler: async function (features) {
           const ids = map(features, feature => isObjectLike(feature) ? getFeatureId(feature) : feature)
           if (isEqual(ids, this.currentFeatureIds)) return
-          console.log('input', ids, this.currentFeatureIds)
+
           await this.unselectAll()
           await Promise.all(map(features, ::this.select))
         },

--- a/src/components/sputnik-source/source.vue
+++ b/src/components/sputnik-source/source.vue
@@ -2,9 +2,7 @@
   import { xyzSource } from '../../mixins'
 
   const SPUTNIK_URL_TEMPLATE = 'http://tiles.maps.sputnik.ru/{z}/{x}/{y}.png?apikey={apikey}'
-  const SPUTNIK_ATTRIBUTIONS = '<a href="http://maps.sputnik.ru/" target="_blank">Спутник</a> ' +
-    '&copy; <a href="http://rt.ru/" target="_blank">Ростелеком</a>, ' +
-    (new Date().getFullYear())
+  const SPUTNIK_ATTRIBUTIONS = '&copy; <a href="http://rt.ru/" target="_blank">Ростелеком</a>. '
 
   export default {
     name: 'VlSourceSputnik',

--- a/src/components/style/icon.vue
+++ b/src/components/style/icon.vue
@@ -59,31 +59,31 @@
         await this.setAnchor(value)
       },
       async src (value) {
-        if (!isEqual(value, await this.getSrc())) {
-          if (process.env.VUELAYERS_DEBUG) {
-            this.$logger.log('src changed, scheduling recreate...')
-          }
+        if (isEqual(value, await this.getSrc())) return
 
-          await this.scheduleRecreate()
+        if (process.env.VUELAYERS_DEBUG) {
+          this.$logger.log('src changed, scheduling recreate...')
         }
+
+        await this.scheduleRecreate()
       },
       async size (value) {
-        if (!isEqual(value, await this.getSize())) {
-          if (process.env.VUELAYERS_DEBUG) {
-            this.$logger.log('size changed, scheduling recreate...')
-          }
+        if (isEqual(value, await this.getSize())) return
 
-          await this.scheduleRecreate()
+        if (process.env.VUELAYERS_DEBUG) {
+          this.$logger.log('size changed, scheduling recreate...')
         }
+
+        await this.scheduleRecreate()
       },
       async color (value) {
-        if (!isEqual(value, await this.getColor())) {
-          if (process.env.VUELAYERS_DEBUG) {
-            this.$logger.log('color changed, scheduling recreate...')
-          }
+        if (isEqual(value, await this.getColor())) return
 
-          await this.scheduleRecreate()
+        if (process.env.VUELAYERS_DEBUG) {
+          this.$logger.log('color changed, scheduling recreate...')
         }
+
+        await this.scheduleRecreate()
       },
       .../*#__PURE__*/makeWatchers([
         'anchorOrigin',

--- a/src/components/tile-arcgis-rest-source/source.vue
+++ b/src/components/tile-arcgis-rest-source/source.vue
@@ -13,7 +13,7 @@
         return new TileArcGISRestSource({
           // ol/source/Source
           attributions: this.currentAttributions,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           wrapX: this.wrapX,
           // ol/source/Tile
           cacheSize: this.cacheSize,

--- a/src/components/tile-wms-source/source.vue
+++ b/src/components/tile-wms-source/source.vue
@@ -35,7 +35,7 @@
         return new TileWMSSource({
           // ol/source/Source
           attributions: this.currentAttributions,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           wrapX: this.wrapX,
           // ol/source/Tile
           cacheSize: this.cacheSize,

--- a/src/components/vector-image-layer/layer.vue
+++ b/src/components/vector-image-layer/layer.vue
@@ -42,7 +42,7 @@
           className: this.className,
           opacity: this.currentOpacity,
           visible: this.currentVisible,
-          extent: this.currentExtentDataProj,
+          extent: this.currentExtentViewProj,
           zIndex: this.currentZIndex,
           minResolution: this.currentMinResolution,
           maxResolution: this.currentMaxResolution,

--- a/src/components/vector-tile-source/source.vue
+++ b/src/components/vector-tile-source/source.vue
@@ -167,7 +167,7 @@
           // ol/source/Source
           attributions: this.currentAttributions,
           attributionsCollapsible: this.attributionsCollapsible,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           state: this.currentState,
           wrapX: this.wrapX,
           // ol/source/Tile

--- a/src/components/wmts-source/source.vue
+++ b/src/components/wmts-source/source.vue
@@ -92,7 +92,7 @@
           return this.tileGridFactory
         }
 
-        const extent = this.extentDataProj || extentFromProjection(this.projection)
+        const extent = this.extentViewProj || extentFromProjection(this.resolvedViewProjection)
         const resolutions = this.resolutions || resolutionsFromExtent(extent, this.maxZoom, this.tileSizeArr)
         const origin = this.originViewProj || getExtentCorner(extent, ExtentCorner.TOP_LEFT)
         const matrixIds = this.matrixIds || range(this.minZoom, resolutions.length)
@@ -176,7 +176,7 @@
         return new WMTSSource({
           // ol/source/Source
           attributions: this.currentAttributions,
-          projection: this.projection,
+          projection: this.resolvedDataProjection,
           wrapX: this.wrapX,
           // ol/source/Tile
           cacheSize: this.cacheSize,

--- a/src/mixins/features-container.js
+++ b/src/mixins/features-container.js
@@ -63,9 +63,6 @@ export default {
         this.$emit('update:features', clonePlainObject(value))
       }, FRAME_TIME),
     },
-    async resolvedDataProjection () {
-      await this.addFeatures(this.currentFeaturesDataProj)
-    },
     featuresCollectionIdent (value, prevValue) {
       if (value && prevValue) {
         this.moveInstance(value, prevValue)
@@ -101,17 +98,19 @@ export default {
     },
     /**
      * @param {FeatureLike[]|module:ol/Collection~Collection<FeatureLike>} features
+     * @param {boolean} [viewProj=false]
      * @return {Promise<void>}
      */
-    async addFeatures (features) {
-      await Promise.all(map(features, ::this.addFeature))
+    async addFeatures (features, viewProj = false) {
+      await Promise.all(map(features, feature => this.addFeature(feature, viewProj)))
     },
     /**
      * @param {FeatureLike} feature
+     * @param {boolean} [viewProj=false]
      * @return {Promise<void>}
      */
-    async addFeature (feature) {
-      feature = await this.initializeFeature(feature)
+    async addFeature (feature, viewProj = false) {
+      feature = await this.initializeFeature(feature, viewProj)
       instanceOf(feature, Feature)
       // todo add hash {featureId => featureIdx, ....}
       const foundFeature = this.getFeatureById(getFeatureId(feature))

--- a/src/mixins/geometry-container.js
+++ b/src/mixins/geometry-container.js
@@ -85,13 +85,18 @@ export default {
     },
     /**
      * @param {GeometryLike|undefined} geom
+     * @param {boolean} [viewProj=false]
      * @return {Promise<void>}
      */
-    async setGeometry (geom) {
+    async setGeometry (geom, viewProj = false) {
       if (isFunction(geom?.resolveOlObject)) {
         geom = await geom.resolveOlObject()
       } else if (isGeoJSONGeometry(geom)) {
-        geom = this.readGeometryInDataProj(geom)
+        if (viewProj) {
+          geom = this.readGeometryInViewProj(geom)
+        } else {
+          geom = this.readGeometryInDataProj(geom)
+        }
       }
       geom || (geom = undefined)
 

--- a/src/mixins/geometry.js
+++ b/src/mixins/geometry.js
@@ -1,5 +1,5 @@
 import { map as mapObs, skipWhile } from 'rxjs/operators'
-import { getGeometryId, initializeGeometry, roundExtent, roundPointCoords, setGeometryId } from '../ol-ext'
+import { EPSG_3857, getGeometryId, initializeGeometry, roundExtent, roundPointCoords, setGeometryId } from '../ol-ext'
 import { fromOlChangeEvent as obsFromOlChangeEvent, fromVueEvent as obsFromVueEvent, fromVueWatcher as obsFromVueWatcher } from '../rx-ext'
 import { assert, addPrefix, hasProp, isEqual, pick, mergeDescriptors, waitFor } from '../utils'
 import olCmp, { OlObjectEvent } from './ol-cmp'
@@ -22,7 +22,8 @@ export default {
   },
   data () {
     return {
-      dataProjection: null,
+      viewProjection: EPSG_3857,
+      dataProjection: EPSG_3857,
     }
   },
   computed: {
@@ -61,9 +62,16 @@ export default {
           ),
           1000,
         )
+        this.viewProjection = this.$mapVm.resolvedViewProjection
         this.dataProjection = this.$mapVm.resolvedDataProjection
-        const dataProjChanges = obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection)
-        this.subscribeTo(dataProjChanges, ({ value }) => { this.dataProjection = value })
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedViewProjection),
+          ({ value }) => { this.viewProjection = value },
+        )
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection),
+          ({ value }) => { this.dataProjection = value },
+        )
         await this.$nextTickPromise()
 
         return this::olCmp.methods.beforeInit()

--- a/src/mixins/interaction.js
+++ b/src/mixins/interaction.js
@@ -1,6 +1,7 @@
 import debounce from 'debounce-promise'
 import { map as mapObs, skipWhile } from 'rxjs/operators'
 import {
+  EPSG_3857,
   getInteractionId,
   getInteractionPriority,
   initializeInteraction,
@@ -51,7 +52,8 @@ export default {
   },
   data () {
     return {
-      dataProjection: null,
+      viewProjection: EPSG_3857,
+      dataProjection: EPSG_3857,
     }
   },
   computed: {
@@ -107,9 +109,16 @@ export default {
           ),
           1000,
         )
+        this.viewProjection = this.$mapVm.resolvedViewProjection
         this.dataProjection = this.$mapVm.resolvedDataProjection
-        const dataProjChanges = obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection)
-        this.subscribeTo(dataProjChanges, ({ value }) => { this.dataProjection = value })
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedViewProjection),
+          ({ value }) => { this.viewProjection = value },
+        )
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection),
+          ({ value }) => { this.dataProjection = value },
+        )
         await this.$nextTickPromise()
 
         return this::olCmp.methods.beforeInit()

--- a/src/mixins/ol-cmp.js
+++ b/src/mixins/ol-cmp.js
@@ -406,19 +406,17 @@ export default {
 }
 
 function defineDebounceMethods () {
-  const t = 1000 / 60
-
   this.debounceRefresh = debounce(function () {
     return this.refresh()
-  }, t)
+  }, FRAME_TIME)
 
   this.debounceRemount = debounce(function () {
     return this.remount()
-  }, t)
+  }, FRAME_TIME)
 
   this.debounceRecreate = debounce(function () {
     return this.recreate()
-  }, t)
+  }, FRAME_TIME)
 }
 
 function defineServices () {

--- a/src/mixins/simple-geometry.js
+++ b/src/mixins/simple-geometry.js
@@ -20,7 +20,7 @@ export default {
     coordinates: {
       type: Array,
       required: true,
-      validator: negate(isEmpty),
+      validator: /*#__PURE__*/negate(isEmpty),
     },
     // todo add support of coord layout
     // /**
@@ -74,10 +74,10 @@ export default {
     // },
   },
   watch: {
-    coordinatesDataProj: {
+    coordinatesViewProj: {
       deep: true,
       async handler (value) {
-        await this.setCoordinates(value)
+        await this.setCoordinates(value, true)
       },
     },
     currentCoordinatesDataProj: {
@@ -130,7 +130,7 @@ export default {
     coordinatesToDataProj (coordinates) {
       const transform = this.getCoordinatesTransformFunction()
 
-      return transform(coordinates, this.viewProjection, this.resolvedDataProjection)
+      return transform(coordinates, this.resolvedViewProjection, this.resolvedDataProjection)
     },
     /**
      * @param {number[]} coordinates
@@ -139,7 +139,7 @@ export default {
     coordinatesToViewProj (coordinates) {
       const transform = this.getCoordinatesTransformFunction()
 
-      return transform(coordinates, this.resolvedDataProjection, this.viewProjection)
+      return transform(coordinates, this.resolvedDataProjection, this.resolvedViewProjection)
     },
     /**
      * @param {boolean} [viewProj=false]

--- a/src/mixins/source.js
+++ b/src/mixins/source.js
@@ -1,7 +1,7 @@
 import debounce from 'debounce-promise'
 import { get as getProj } from 'ol/proj'
 import { map as mapObs, skipWhile } from 'rxjs/operators'
-import { getSourceId, initializeSource, setSourceId } from '../ol-ext'
+import { EPSG_3857, getSourceId, initializeSource, setSourceId } from '../ol-ext'
 import {
   fromOlChangeEvent as obsFromOlChangeEvent,
   fromVueEvent as obsFromVueEvent,
@@ -63,7 +63,8 @@ export default {
   },
   data () {
     return {
-      dataProjection: null,
+      viewProjection: EPSG_3857,
+      dataProjection: EPSG_3857,
     }
   },
   computed: {
@@ -145,9 +146,16 @@ export default {
           ),
           1000,
         )
+        this.viewProjection = this.$mapVm.resolvedViewProjection
         this.dataProjection = this.$mapVm.resolvedDataProjection
-        const dataProjChanges = obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection)
-        this.subscribeTo(dataProjChanges, ({ value }) => { this.dataProjection = value })
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedViewProjection),
+          ({ value }) => { this.viewProjection = value },
+        )
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection),
+          ({ value }) => { this.dataProjection = value },
+        )
         await this.$nextTickPromise()
 
         return this::olCmp.methods.beforeInit()

--- a/src/mixins/style.js
+++ b/src/mixins/style.js
@@ -1,6 +1,6 @@
 import { map as mapObs } from 'rxjs/operators'
-import { getStyleId, initializeStyle, setStyleId } from '../ol-ext'
-import { fromVueEvent as obsFromVueEvent } from '../rx-ext'
+import { EPSG_3857, getStyleId, initializeStyle, setStyleId } from '../ol-ext'
+import { fromVueEvent as obsFromVueEvent, fromVueWatcher as obsFromVueWatcher } from '../rx-ext'
 import { assert, hasProp, pick, mergeDescriptors, waitFor } from '../utils'
 import olCmp, { OlObjectEvent } from './ol-cmp'
 import stubVNode from './stub-vnode'
@@ -17,6 +17,12 @@ export default {
     empty () {
       return this.vmId
     },
+  },
+  data () {
+    return {
+      viewProjection: EPSG_3857,
+      dataProjection: EPSG_3857,
+    }
   },
   created () {
     this::defineServices()
@@ -37,6 +43,17 @@ export default {
           ),
           1000,
         )
+        this.viewProjection = this.$mapVm.resolvedViewProjection
+        this.dataProjection = this.$mapVm.resolvedDataProjection
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedViewProjection),
+          ({ value }) => { this.viewProjection = value },
+        )
+        this.subscribeTo(
+          obsFromVueWatcher(this, () => this.$mapVm.resolvedDataProjection),
+          ({ value }) => { this.dataProjection = value },
+        )
+        await this.$nextTickPromise()
 
         return this::olCmp.methods.beforeInit()
       } catch (err) {

--- a/src/mixins/url-tile-source.js
+++ b/src/mixins/url-tile-source.js
@@ -4,7 +4,7 @@ import { fromOlEvent as obsFromOlEvent } from '../rx-ext'
 import { and, isEmpty, isEqual, isString, negate, pick, replaceTokens } from '../utils'
 import tileSource from './tile-source'
 
-const isNotEmptyString = and(isString, negate(isEmpty))
+const isNotEmptyString = /*#__PURE__*/and(isString, negate(isEmpty))
 
 export default {
   mixins: [

--- a/src/mixins/xyz-source.js
+++ b/src/mixins/xyz-source.js
@@ -40,7 +40,7 @@ export default {
         return this.tileGridFactory
       }
 
-      const extent = extentFromProjection(this.projection)
+      const extent = extentFromProjection(this.resolvedViewProjection)
       const maxZoom = this.maxZoom
       const minZoom = this.minZoom
       const maxResolution = this.maxResolution
@@ -67,7 +67,7 @@ export default {
         // ol/source/Source
         attributions: this.currentAttributions,
         attributionsCollapsible: this.attributionsCollapsible,
-        projection: this.projection,
+        projection: this.resolvedDataProjection,
         wrapX: this.wrapX,
         // ol/source/Tile
         cacheSize: this.cacheSize,

--- a/src/rx-ext/observable.js
+++ b/src/rx-ext/observable.js
@@ -65,9 +65,9 @@ export function fromOlChangeEvent (
     return mergeObs(...prop.map(p => fromOlChangeEvent(target, p, distinct, selector)))
   }
 
-  selector = selector || ((target, prop) => target.get(prop))
+  selector || (selector = identity)
   const event = `change:${prop}`
-  const observable = fromOlEvent(target, event, () => selector(target, prop))
+  const observable = fromOlEvent(target, event, () => target.get(prop))
   const operations = []
 
   if (distinct) {
@@ -75,7 +75,7 @@ export function fromOlChangeEvent (
     operations.push(distinctUntilChanged(distinct))
   }
 
-  operations.push(mapObs(value => ({ prop, value })))
+  operations.push(mapObs(value => selector({ prop, value })))
 
   return observable.pipe(...operations)
 }

--- a/tests/app.vue
+++ b/tests/app.vue
@@ -1,36 +1,45 @@
 <template>
   <div id="app">
     <VlMap
-      ref="map">
+      ref="map"
+      :data-projection="dataProj">
       <VlView
         ref="view"
         :center.sync="center"
-        :zoom.sync="zoom" />
+        :zoom.sync="zoom"
+        :projection="viewProj" />
 
       <VlLayerTile>
         <VlSourceOsm />
       </VlLayerTile>
 
+      <VlLayerTile>
+        <VlSourceWmts
+          url="https://services.arcgisonline.com/arcgis/rest/services/Demographics/USA_Population_Density/MapServer/WMTS/"
+          layer-name="0"
+          matrix-set="EPSG:3857"
+          format="image/png"
+          projection="EPSG:3857"
+          style-name="default"
+          :resolutions="resolutions"
+          :matrix-dds="matrixIds" />
+      </VlLayerTile>
+
       <VlLayerVector>
         <VlSourceVector
+          ident="draw"
           :features="features"
-          projection="EPSG:4326" />
+          :projection="featProj" />
       </VlLayerVector>
-
-      <VlLayerTile>
-        <VlSourceTileWms
-          url="https://wms.geo.admin.ch/"
-          projection="EPSG:21781"
-          layers="ch.swisstopo.pixelkarte-farbe-pk1000.noscale"
-          cross-origin="anonymous" />
-      </VlLayerTile>
     </VlMap>
   </div>
 </template>
 
 <script>
-  import proj4 from 'proj4'
+  import { getWidth } from 'ol/extent'
+  import { get as getProjection } from 'ol/proj'
   import { register } from 'ol/proj/proj4'
+  import proj4 from 'proj4'
 
   proj4.defs(
     'EPSG:21781',
@@ -38,25 +47,82 @@
       '+lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
       '+towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs',
   )
+  proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +units=m +no_defs')
   register(proj4)
+
+  const projection = getProjection('EPSG:3857')
+  const projectionExtent = projection.getExtent()
+  const size = getWidth(projectionExtent) / 256
+  const resolutions = new Array(14)
+  const matrixIds = new Array(14)
+  for (let z = 0; z < 14; ++z) {
+    // generate resolutions and matrixIds arrays for this WMTS
+    resolutions[z] = size / Math.pow(2, z)
+    matrixIds[z] = z
+  }
 
   export default {
     name: 'App',
     data () {
       return {
-        zoom: 3,
-        center: [0, 0],
+        center: [598703.7995171356, 6225813.035968694],
+        // center: [8.4, 56.4],
+        zoom: 6,
         rotation: 0,
-        features: [
-          {
-            type: 'Feature',
-            geometry: {
-              type: 'Point',
-              coordinates: [20, 20],
-            },
-          },
-        ],
+        features: [],
+        dataProj: 'EPSG:25832',
+        viewProj: 'EPSG:25832',
+        featProj: 'EPSG:4326',
+        selectedFeatures: [],
+        resolutions,
+        matrixIds,
       }
+    },
+    mounted () {
+      this.features = [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [8.41552734375, 56.41390137600676],
+                [8.173828125, 55.4040698270061],
+                [10.04150390625, 55.02802211299252],
+                [10.87646484375, 55.85064987433714],
+                [9.33837890625, 55.801280971180454],
+                [9.64599609375, 56.401744392758964],
+                [11.2939453125, 56.389583525613055],
+                [11.44775390625, 55.7765730186677],
+                [12.041015625, 56.401744392758964],
+                [11.557617187499998, 56.728621973140726],
+                [9.16259765625, 56.80087831233043],
+                [8.41552734375, 56.41390137600676],
+              ],
+            ],
+          },
+        },
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [9.9371337890625, 56.258608725706935],
+                [9.931640625, 55.979945357882315],
+                [10.4864501953125, 55.979945357882315],
+                [10.546875, 56.14860953861174],
+                [10.37109375, 56.28605924471002],
+                [10.2777099609375, 56.07816700469287],
+                [10.107421874999998, 56.105746831832036],
+                [9.9371337890625, 56.258608725706935],
+              ],
+            ],
+          },
+        },
+      ]
     },
   }
 </script>


### PR DESCRIPTION
Resolve data/view projections from vl-map vm, then watch for their changes. Compare coordinates in view projection, so this fields always trigger watcher on resolvedViewProjection change.

#356 