### PR TITLE
set NODE_ENV for esm build

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -84,7 +84,10 @@ module.exports = [
   {
     ...baseConf,
     external: makeExternal(config.dependencies.concat(['../../mixins', '../../ol-ext', '../../rx-ext', '../../utils'])),
-    plugins: makePlugins(false, null, `dist/${config.name}.css`),
+    plugins: makePlugins(false, {
+      'process.env.NODE_ENV': "'production'",
+      'process.env.VUELAYERS_DEBUG': 'false',
+    }, `dist/${config.name}.css`),
     output: {
       ...baseConf.output,
       file: utils.resolve(`dist/${config.name}.esm.js`),


### PR DESCRIPTION
Right now the ESM build does not have NODE_ENV and VUELAYERS_DEBUG variables set. 
This results in a bug when using Vue2 + Vite because vite does not expose process.env -> [vite docs](https://vitejs.dev/guide/env-and-mode.html)

![image](https://user-images.githubusercontent.com/6354070/171513638-4d948709-c41c-4a2a-b257-b4daa3c0b24a.png)

This PR sets both variables for esm build.
