### PR TITLE
src/ol-ext: fix validation GeoJSON GeometryCollection geometry coordinates type

### DIFF
--- a/src/ol-ext/format.js
+++ b/src/ol-ext/format.js
@@ -347,5 +347,7 @@ export function isGeoJSONFeature (feature) {
 export function isGeoJSONGeometry (geometry) {
   return isPlainObject(geometry) &&
     Object.values(GeometryType).includes(geometry.type) &&
-    isArray(geometry.coordinates)
+    geometry.geometries
+      ? geometry.geometries.every((geometry) => isArray(geometry.coordinates))
+      : isArray(geometry.coordinates)
 }


### PR DESCRIPTION
**Describe the bug**
The `<vl-interaction-select>` component incorrectly validate `feature` property if it is GeoJSON GeometryCollection geometry type.

**To Reproduce**
Steps to reproduce the behavior:

1. Use `<vl-source-vector>` component which load GeoJSON GeometryCollection geometry type data and `<vl-interaction-select>` component.

Example:

```vue
   <!-- POI vector layer -->
    <vl-layer-vector :id="poiLayerId">
      <vl-source-vector
        :wrap-x="true"
        :loader-factory="poiFeaturesLoader"
        :strategy-factory="loadingStrategyFactory"
        :attributions="attributions"
        :ref="poiLayerId"
      >
        <vl-style-func :factory="poiFeatureStyleFuncFactory" />
      </vl-source-vector>
    </vl-layer-vector>

    <vl-interaction-select
      :features.sync="selectedFeatures"
      ref="selectPoiFeature"
      :hitTolerance="hitTolerance"
      :filter="filterPOILayer"
    >
      <vl-style-func
        :factory="selectedPoiFeatureStyleFuncFactory"
      ></vl-style-func>
    </vl-interaction-select>
```
3. Click on the feature on the map.
4. See error inside web browser console

Error:

```
19:47:00.398 [Vue warn]: Invalid prop: custom validator check failed for prop "features".

found in

---> <VlInteractionSelect>
       <PoiVector>
         <VlMap>
           <Map> at src/components/Map.vue
             <QPage>
               <PageIndex> at src/pages/Index.vue
                 <QPageContainer>
                   <QLayout>
                     <MainLayout> at src/layouts/MainLayout.vue
                       <App> at src/App.vue
                         <Root> vue.runtime.esm.js:619
    VueJS 23
    changed mixins.js:759
    flush index.js:54
    debounced index.js:38
    3 mixins.js:3877
    RxJS 35
    dispatchEvent Target.js:118
    insertAt Collection.js:202
    push Collection.js:224
    extend Collection.js:144
    handleEvent Select.js:475
    handleMapBrowserEvent PluggableMap.js:987
    dispatchEvent Target.js:118
    clickTimeoutId_ MapBrowserEventHandler.js:130
```

**Expected behavior**
`<vl-interaction-select>` component should be properly validate `feature` property if it is GeoJSON GeometryCollection geometry type.

**Additional context:**
For validation GeoJSON GeometryCollection geometry coordinates type is correct path `feature.geometry.geometries[0].coordinates`

https://github.com/ghettovoice/vuelayers/blob/6dc131fe26e4ff9b0f25dfbb1c6f4ec9d7eebba3/src/ol-ext/format.js#L350

 Example of a GeometryCollection:

```json
{ "type": "GeometryCollection",
"geometries": [
  { "type": "Point",
    "coordinates": [100.0, 0.0]
    },
  { "type": "LineString",
    "coordinates": [ [101.0, 0.0], [102.0, 1.0] ]
    }
 ]
}
```