### PR TITLE
Quickstart - consistent case on vuelayer

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,7 +70,7 @@ plugins: [{
 	}, { ... }],
 modules: [
                 ...,
-		'~/shared/vueLayers',
+		'~/shared/vuelayers',
 	],
 ```
 


### PR DESCRIPTION
On `nuxt.config.js`, `vuelayers` need to be the same case as the filename ( `shared/vuelayers.js`). 

If the case is different, `nuxt generate` will be successfull on Windows but fail on Linux, which is case sensitive for the filenames. 